### PR TITLE
fix: match path

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
       "pre-commit": "lint-staged"
     }
   },
-  "dependencies": {},
   "devDependencies": {
     "@commitlint/cli": "^12.1.4",
     "@commitlint/config-conventional": "^12.1.4",

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,7 +9,7 @@ export function getItemsByPath(items, pathname) {
       return { ...acc, [val.rootPath]: val };
     }, {}) ?? {};
   const matchingPaths = Object.keys(itemsByPath)
-    .filter((path) => pathname.startsWith(path))
+    .filter((path) => pathname === path || pathname.startsWith(`${path}/`))
     .sort((a, b) => {
       if (a.length > b.length) return -1;
       else if (a.length < b.length) return 1;


### PR DESCRIPTION
this fix handles this cases:

i've configured a subfooter in controlpanel for  _"/**test**"_

if i navigate to _"/**test**-number-one"_ now this path doesn't matches
if i navigate to _"/pippo/pluto/**test**"_ now this path doesn't matches (before it was matching and it was wrong)

