### PR TITLE
fix: removed unused prevent click

### DIFF
--- a/src/widget/SubFooterConfigurationForm.jsx
+++ b/src/widget/SubFooterConfigurationForm.jsx
@@ -48,33 +48,23 @@ const SubFooterConfigurationForm = ({
 }) => {
   const intl = useIntl();
 
-  const preventClick = (e) => {
-    e.preventDefault();
-  };
-
   const preventEnter = (e) => {
     if (e.code === 'Enter') {
-      preventClick(e);
+      e.preventDefault();
     }
   };
 
   useEffect(() => {
-    document
-      .querySelector('form.ui.form')
-      .addEventListener('click', preventClick);
-
     document.querySelectorAll('form.ui.form input').forEach((item) => {
       item.addEventListener('keypress', preventEnter);
     });
 
     return () => {
-      document
-        .querySelector('form.ui.form')
-        ?.removeEventListener('click', preventClick);
       document.querySelectorAll('form.ui.form input').forEach((item) => {
-        item.removeEventListener('keypress', preventEnter);
+        item?.removeEventListener('keypress', preventEnter);
       });
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const onChangeFormData = (id, value) => {

--- a/src/widget/SubFooterConfigurationForm.jsx
+++ b/src/widget/SubFooterConfigurationForm.jsx
@@ -48,18 +48,31 @@ const SubFooterConfigurationForm = ({
 }) => {
   const intl = useIntl();
 
-  const preventEnter = (e) => {
-    if (e.code === 'Enter') {
+  const preventClick = (e) => {
+    // only prevent default when the click is on a button
+    const btn = e.target?.closest && e.target.closest('button');
+    if (btn) {
       e.preventDefault();
     }
   };
 
+  const preventEnter = (e) => {
+    if (e.code === 'Enter') {
+      const btn = e.target?.closest && e.target.closest('button');
+      if (btn) preventClick(e);
+    }
+  };
+
   useEffect(() => {
+    const form = document.querySelector('form.ui.form');
+    form?.addEventListener('click', preventClick);
+
     document.querySelectorAll('form.ui.form input').forEach((item) => {
       item.addEventListener('keypress', preventEnter);
     });
 
     return () => {
+      form?.removeEventListener('click', preventClick);
       document.querySelectorAll('form.ui.form input').forEach((item) => {
         item?.removeEventListener('keypress', preventEnter);
       });

--- a/src/widget/SubFooterConfigurationForm.jsx
+++ b/src/widget/SubFooterConfigurationForm.jsx
@@ -48,38 +48,41 @@ const SubFooterConfigurationForm = ({
 }) => {
   const intl = useIntl();
 
-  const preventClick = (e) => {
-    // only prevent default when the click is on a button
-    const btn = e.target?.closest && e.target.closest('button');
-    if (btn) {
-      e.preventDefault();
-    }
-  };
-
-  const preventEnter = (e) => {
-    if (e.code === 'Enter') {
-      const btn = e.target?.closest && e.target.closest('button');
-      if (btn) preventClick(e);
-    }
-  };
-
   useEffect(() => {
+    // Get the main Volto HTML form
     const form = document.querySelector('form.ui.form');
-    form?.addEventListener('click', preventClick);
 
-    document.querySelectorAll('form.ui.form input').forEach((item) => {
-      item.addEventListener('keypress', preventEnter);
-    });
+    // Handler to block any type of submit
+    const preventSubmit = (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+    };
+
+    // global handler to stop Enter from submitting inputs
+
+    const handleEnter = (e) => {
+      if (e.key === 'Enter') {
+        const targetForm = e.target.closest('form.ui.form');
+        if (targetForm) {
+          // block enter everywhere else to prevent unwanted submit
+          e.preventDefault();
+          e.stopPropagation();
+        }
+      }
+    };
+
+    // prevent native submits (click on buttons that have type submit, etc.)
+    form?.addEventListener('submit', preventSubmit, true);
+
+    // Block Enter outside blocks
+    document.addEventListener('keydown', handleEnter, true);
 
     return () => {
-      form?.removeEventListener('click', preventClick);
-      document.querySelectorAll('form.ui.form input').forEach((item) => {
-        item?.removeEventListener('keypress', preventEnter);
-      });
+      // Cleanup all listeners
+      form?.removeEventListener('submit', preventSubmit, true);
+      document.removeEventListener('keydown', handleEnter, true);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
   const onChangeFormData = (id, value) => {
     onChange({ ...menuItem, [id]: value });
   };


### PR DESCRIPTION
The preventClick function set on all form prevents checkbox onChange to have effects.

Same issue as https://github.com/collective/volto-dropdownmenu/pull/36

The problem is that the click is not applied to the component. No onChange function at any level is even triggered, which means that it is not a id problem or a onChange function problem, but the fact that the click does not trigger anything inside the component.

This does not happen on other widgets because the components (text input, buttons, etc.) intercept the click before the preventClick does as it does not propagate.
Since it seems there is actually no need for a preventClick function, I would just remove it and keep the preventEnter as it is the one that prevents the real risk of submitting the form.

I guessed  preventClick was introduced to avoid any submissions of the form, but removing it does not seem to change anything besides making the Checkbox work.
We tried to

- change menu item
- change menu navigation tab
- remove or add item menus to the same tab
- remove or add tabs to the navigation tabs
- changing other fields

the network tab does not show any submits nor the form seems to have any issues.